### PR TITLE
add custom field support to homepages

### DIFF
--- a/classes/class-homepages.php
+++ b/classes/class-homepages.php
@@ -106,7 +106,7 @@ class Homepages {
 			'show_in_rest'        => true,
 			'rewrite'             => false,
 			'menu_icon'           => 'dashicons-admin-home',
-			'supports'            => [ 'title', 'editor', 'thumbnail', 'revisions' ],
+			'supports'            => [ 'title', 'editor', 'thumbnail', 'revisions', 'custom-fields' ],
 		];
 
 		register_post_type( $this->post_type, $args );


### PR DESCRIPTION
Without custom field support, homepage CPT is incompatible with our current WP Starter Plugin Sidebar.