### PR TITLE
Add support for static home page setups

### DIFF
--- a/classes/class-homepages.php
+++ b/classes/class-homepages.php
@@ -139,7 +139,7 @@ class Homepages {
 			if ( ! is_user_logged_in() ) {
 				$wp_query->set_404();
 			} else {
-				$wp_query->is_home = true;
+				$wp_query->is_home = ( 'posts' === get_option( 'show_on_front' ) );
 			}
 		}
 	}


### PR DESCRIPTION
This allows you to use this plugin with a WordPress setup where you've set your site to a static homepage, which allows you to select a page for displaying your main posts archive, i.e. the blog page.

Adds a new method: `Homepages\is_front_page()` to test whether the current wp_query object should be treated like a front page query and updates the `update_is_home_conditional` method to only set `is_home` to true when the site is configured to show the latest posts on the front page.