### PR TITLE
Fix homepage query when a static page is set

### DIFF
--- a/classes/class-homepages.php
+++ b/classes/class-homepages.php
@@ -84,6 +84,8 @@ class Homepages {
 		) {
 			$wp_query->set( 'post_type', $this->post_type );
 			$wp_query->set( 'posts_per_page', 1 );
+			// Reset the page ID if using static pages for the homepage.
+			$wp_query->set( 'page_id', null );
 		}
 	}
 


### PR DESCRIPTION
This resets the `page_id` argument in the main wp_query object so the ID for a static page isn't used in the query.