### PR TITLE
Update composer project type to 'wordpress-plugin'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "alleyinteractive/homepages",
     "description": "Homepages",
-    "type": "project",
+    "type": "wordpress-plugin",
     "authors": [
       {
         "name": "Alley Interactive",


### PR DESCRIPTION
This will let the `composer/installers` package auto-install this plugin to the `plugins` directory, unless otherwise specified in `extra.installer-paths`.