### PR TITLE
Buddy: Fix git conflict check

### DIFF
--- a/buddy.yml
+++ b/buddy.yml
@@ -27,7 +27,7 @@
       docker_image_name: "alleyops/ci-resources"
       docker_image_tag: "7.4-fpm-wp"
       execute_commands:
-        - "! git grep -E '<<<<<<< HEAD|=======.*>>>>>>>' \":!$0\""
+        - "! git grep -E \"<<<<<<< |>>>>>>> \" -- './*' ':!buddy.yml' ':!.buddy/*'"
       volume_mappings:
         - "/:/buddy/homepages"
       trigger_condition: "ALWAYS"


### PR DESCRIPTION
This fixes an issue where the buddy config file was being caught during the check for git conflicts action.