### PR TITLE
do not return empty value for homepage id ever

### DIFF
--- a/classes/class-homepages.php
+++ b/classes/class-homepages.php
@@ -211,7 +211,7 @@ class Homepages {
 		$homepage_id = get_transient( $cache_key );
 
 		// We have a cache hit, so lets use that.
-		if ( false !== $homepage_id ) {
+		if ( ! empty( $homepage_id ) ) {
 			return (int) $homepage_id;
 		}
 


### PR DESCRIPTION
As titled. It is never in the interest of an end use for an empty cached value to be returned.